### PR TITLE
[M2] 更新ボタンで Issue / Sub-issue を再取得する

### DIFF
--- a/src/actions/hierarchy-actions.ts
+++ b/src/actions/hierarchy-actions.ts
@@ -6,6 +6,7 @@ import {
   removeSubIssue,
   fetchSubIssues,
   reprioritizeSubIssue,
+  fetchParentIssueNumber,
 } from "@/lib/github/sub-issues";  // Sub-Issue 操作
 import type { GitHubIssue, IssueId } from "@/lib/github/types";  // 型
 
@@ -66,6 +67,7 @@ export async function reorderSubIssue(
 export async function moveIssueToParent(
   owner: string,
   repo: string,
+  issueNumber: number,
   issueId: IssueId,
   oldParentIssueNumber: number | null,
   newParentIssueNumber: number | null,
@@ -73,14 +75,33 @@ export async function moveIssueToParent(
   beforeId?: IssueId
 ): Promise<void> {
   const octokit = await createOctokit();
+  const actualParentNumber = await fetchParentIssueNumber(
+    octokit,
+    owner,
+    repo,
+    issueNumber
+  );
 
-  // 旧親から削除
-  if (oldParentIssueNumber !== null) {
-    await removeSubIssue(octokit, owner, repo, oldParentIssueNumber, issueId);
+  // 旧親から削除（実親を優先。取得不可時のみ oldParent をフォールバック）
+  const parentToDetach =
+    actualParentNumber ?? oldParentIssueNumber;
+
+  if (
+    parentToDetach !== null &&
+    (newParentIssueNumber === null || parentToDetach !== newParentIssueNumber)
+  ) {
+    try {
+      await removeSubIssue(octokit, owner, repo, parentToDetach, issueId);
+    } catch (error) {
+      // 連続操作の圧縮時は既に外れている場合があるため 404 は許容
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const status = (error as any)?.status;
+      if (status !== 404) throw error;
+    }
   }
 
   // 新親に追加
-  if (newParentIssueNumber !== null) {
+  if (newParentIssueNumber !== null && actualParentNumber !== newParentIssueNumber) {
     await addSubIssue(octokit, owner, repo, newParentIssueNumber, issueId);
 
     // 位置指定がある場合は並び替え

--- a/src/app/(app)/repos/page.tsx
+++ b/src/app/(app)/repos/page.tsx
@@ -1,7 +1,17 @@
+import { redirect } from "next/navigation";  // リダイレクト
 import { getRepos } from "@/actions/issue-actions";  // リポジトリ取得
 import { RepoList } from "@/components/layout/RepoList";  // リポジトリ一覧コンポーネント
+import { isDevMode } from "@/lib/auth-mode";  // Dev モード判定
 
 export default async function ReposPage() {
+  if (!isDevMode()) {
+    const { auth } = await import("@/auth");
+    const session = await auth();
+    if (!session?.accessToken) {
+      redirect("/login");
+    }
+  }
+
   const repos = await getRepos();  // Server Action でリポジトリ取得
 
   return (

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,7 +1,13 @@
 import NextAuth from "next-auth";  // Auth.js v5 をインポート
 import GitHub from "next-auth/providers/github";  // GitHub OAuth プロバイダー
 
+const authSecret =
+  process.env.AUTH_SECRET ??
+  process.env.NEXTAUTH_SECRET ??
+  (process.env.NODE_ENV === "development" ? "local-dev-insecure-auth-secret" : undefined);
+
 export const { handlers, signIn, signOut, auth } = NextAuth({
+  secret: authSecret,
   providers: [
     GitHub({
       authorization: {

--- a/src/components/outliner/OutlinerRoot.tsx
+++ b/src/components/outliner/OutlinerRoot.tsx
@@ -1,8 +1,7 @@
 "use client";  // クライアントコンポーネント
 
-import { useEffect, useCallback, useRef } from "react";  // React フック
+import { useEffect, useCallback, useRef, useState } from "react";  // React フック
 import { useIssues } from "@/hooks/useIssues";  // Issue 取得
-import { useSubIssues } from "@/hooks/useSubIssues";  // 子 Issue 取得
 import { useMutateIssue } from "@/hooks/useMutateIssue";  // Issue 操作
 import { useTreeStore } from "@/stores/tree-store";  // ツリー状態
 import { useUIStore } from "@/stores/ui-store";  // UI 状態
@@ -13,9 +12,10 @@ import { Breadcrumb } from "./Breadcrumb";  // ブレッドクラム
 import { SortableTree } from "./SortableTree";  // DnD ラッパー
 import { Skeleton } from "@/components/ui/skeleton";  // スケルトン
 import { Button } from "@/components/ui/button";  // ボタン
-import { Plus, Eye, EyeOff, ExternalLink } from "lucide-react";  // アイコン
-import type { GitHubIssue, IssueId } from "@/lib/github/types";  // 型
+import { Plus, Eye, EyeOff, ExternalLink, RefreshCw } from "lucide-react";  // アイコン
+import type { GitHubIssue } from "@/lib/github/types";  // 型
 import Link from "next/link";  // ルーティング
+import { toast } from "sonner";  // 通知
 
 interface Props {
   owner: string;  // リポジトリオーナー
@@ -25,8 +25,8 @@ interface Props {
 
 export function OutlinerRoot({ owner, repo }: Props) {
   const { issues, isLoading, mutate: mutateIssues } = useIssues(owner, repo);  // Issue 取得
+  const [isRefreshing, setIsRefreshing] = useState(false);  // 手動更新中
   const {
-    tree,
     flatItems,
     collapsedIds,
     zoomId,
@@ -42,8 +42,11 @@ export function OutlinerRoot({ owner, repo }: Props) {
   const loadedParentsRef = useRef<Set<number>>(new Set());
 
   /** Issue リストからツリーを構築 */
-  const rebuildTree = useCallback(() => {
-    if (issues.length === 0) return;
+  const rebuildTree = useCallback((sourceIssues: GitHubIssue[] = issues) => {
+    if (sourceIssues.length === 0) {
+      setTree([]);
+      return;
+    }
 
     // ルート Issue（sub_issues_summary を持つが、どの子にも含まれていないもの）を特定
     const childIds = new Set<number>();
@@ -53,7 +56,7 @@ export function OutlinerRoot({ owner, repo }: Props) {
       }
     }
 
-    const rootIssues = issues.filter((i) => !childIds.has(i.id));
+    const rootIssues = sourceIssues.filter((i) => !childIds.has(i.id));
     const builtTree = buildTree(rootIssues, childrenMapRef.current, collapsedIds);
     setTree(builtTree);
   }, [issues, collapsedIds, setTree]);
@@ -65,7 +68,11 @@ export function OutlinerRoot({ owner, repo }: Props) {
 
   /** 子 Issue を遅延ロード */
   const loadSubIssues = useCallback(
-    async (issueNumber: number) => {
+    async (
+      issueNumber: number,
+      sourceIssues: GitHubIssue[] = issues,
+      options?: { propagateError?: boolean }
+    ) => {
       if (loadedParentsRef.current.has(issueNumber)) return;  // ロード済み
       loadedParentsRef.current.add(issueNumber);
 
@@ -78,24 +85,27 @@ export function OutlinerRoot({ owner, repo }: Props) {
           // 子 Issue のさらに子もロード
           for (const sub of subIssues) {
             if (sub.sub_issues_summary && sub.sub_issues_summary.total > 0) {
-              await loadSubIssues(sub.number);
+              await loadSubIssues(sub.number, sourceIssues, options);
             }
           }
 
-          rebuildTree();
+          rebuildTree(sourceIssues);
         }
       } catch (error) {
         console.error(`Failed to load sub-issues for #${issueNumber}:`, error);
+        if (options?.propagateError) {
+          throw error;
+        }
       }
     },
-    [owner, repo, rebuildTree]
+    [owner, repo, rebuildTree, issues]
   );
 
   // sub_issues_summary がある Issue の子を自動ロード
   useEffect(() => {
     for (const issue of issues) {
       if (issue.sub_issues_summary && issue.sub_issues_summary.total > 0) {
-        loadSubIssues(issue.number);
+        loadSubIssues(issue.number, issues);
       }
     }
   }, [issues, loadSubIssues]);
@@ -120,6 +130,33 @@ export function OutlinerRoot({ owner, repo }: Props) {
       mutateIssues();
     }
   }, [create, mutateIssues]);
+
+  /** Issue / Sub-issue を手動更新 */
+  const handleRefresh = useCallback(async () => {
+    setIsRefreshing(true);
+
+    try {
+      childrenMapRef.current.clear();
+      loadedParentsRef.current.clear();
+
+      const latestIssues = (await mutateIssues()) ?? [];
+      rebuildTree(latestIssues);
+
+      for (const issue of latestIssues) {
+        if (issue.sub_issues_summary && issue.sub_issues_summary.total > 0) {
+          await loadSubIssues(issue.number, latestIssues, { propagateError: true });
+        }
+      }
+
+      rebuildTree(latestIssues);
+      toast.success("最新状態に更新しました");
+    } catch (error) {
+      console.error("Failed to refresh issues:", error);
+      toast.error("更新に失敗しました");
+    } finally {
+      setIsRefreshing(false);
+    }
+  }, [mutateIssues, rebuildTree, loadSubIssues]);
 
   if (isLoading) {
     return (
@@ -155,6 +192,16 @@ export function OutlinerRoot({ owner, repo }: Props) {
         </div>
 
         <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleRefresh}
+            disabled={isRefreshing}
+            className="gap-1 text-xs"
+          >
+            <RefreshCw className={`h-3.5 w-3.5 ${isRefreshing ? "animate-spin" : ""}`} />
+            更新
+          </Button>
           <Button
             variant="ghost"
             size="sm"

--- a/src/components/outliner/SortableTree.tsx
+++ b/src/components/outliner/SortableTree.tsx
@@ -31,6 +31,7 @@ interface Props {
   flatItems: FlattenedItem[];  // フラットアイテム
   moveToParent: (
     id: IssueId,
+    issueNumber: number,
     oldParent: number | null,
     newParent: number | null,
     afterId?: IssueId,
@@ -136,6 +137,7 @@ export function SortableTree({
         const overItem = flatItems.find((i) => i.issue.id === over.id);
         await moveToParent(
           active.id as IssueId,
+          activeItem.issue.number,
           oldParentNumber,
           newParentNumber ?? (projection.position === "child" ? overItem?.issue.number ?? null : null),
           overItem?.issue.id

--- a/src/components/ui/breadcrumb.tsx
+++ b/src/components/ui/breadcrumb.tsx
@@ -66,9 +66,9 @@ function BreadcrumbSeparator({
   children,
   className,
   ...props
-}: React.ComponentProps<"li">) {
+}: React.ComponentProps<"span">) {
   return (
-    <li
+    <span
       data-slot="breadcrumb-separator"
       role="presentation"
       aria-hidden="true"
@@ -76,7 +76,7 @@ function BreadcrumbSeparator({
       {...props}
     >
       {children ?? <ChevronRight />}
-    </li>
+    </span>
   )
 }
 

--- a/src/hooks/useIssues.ts
+++ b/src/hooks/useIssues.ts
@@ -4,6 +4,8 @@ import useSWR from "swr";  // データフェッチ + キャッシュ
 import { getIssues } from "@/actions/issue-actions";  // Server Action
 import type { GitHubIssue } from "@/lib/github/types";  // 型
 
+const EMPTY_ISSUES: GitHubIssue[] = [];
+
 /** Issue 一覧を SWR で取得するフック */
 export function useIssues(owner: string, repo: string) {
   const { data, error, isLoading, mutate } = useSWR<GitHubIssue[]>(
@@ -16,7 +18,7 @@ export function useIssues(owner: string, repo: string) {
   );
 
   return {
-    issues: data ?? [],  // デフォルト空配列
+    issues: data ?? EMPTY_ISSUES,  // デフォルト空配列（安定参照）
     error,
     isLoading,
     mutate,  // 手動再検証用

--- a/src/hooks/useMutateIssue.ts
+++ b/src/hooks/useMutateIssue.ts
@@ -1,26 +1,250 @@
 "use client";  // クライアントフック
 
-import { useCallback } from "react";  // コールバック最適化
+import { useCallback, useRef } from "react";  // コールバック最適化
 import { useSWRConfig } from "swr";  // SWR グローバルミュータ
 import { createNewIssue, updateExistingIssue } from "@/actions/issue-actions";  // Issue CRUD
 import {
   addChildIssue,
-  removeChildIssue,
   moveIssueToParent,
   reorderSubIssue,
 } from "@/actions/hierarchy-actions";  // 階層操作
 import type { GitHubIssue, IssueId, IssueNumber } from "@/lib/github/types";  // 型
+import type { TreeItem } from "@/lib/tree/types";  // ツリー型
+import { useTreeStore } from "@/stores/tree-store";  // ツリーストア
 import { toast } from "sonner";  // トースト通知
+
+function insertByAnchor(
+  items: TreeItem[],
+  node: TreeItem,
+  afterId?: IssueId,
+  beforeId?: IssueId
+): TreeItem[] {
+  const next = [...items];
+
+  if (beforeId !== undefined) {
+    const index = next.findIndex((item) => item.issue.id === beforeId);
+    if (index >= 0) {
+      next.splice(index, 0, node);
+      return next;
+    }
+  }
+
+  if (afterId !== undefined) {
+    const index = next.findIndex((item) => item.issue.id === afterId);
+    if (index >= 0) {
+      next.splice(index + 1, 0, node);
+      return next;
+    }
+  }
+
+  next.push(node);
+  return next;
+}
+
+function detachNode(
+  items: TreeItem[],
+  issueId: IssueId
+): { items: TreeItem[]; node: TreeItem | null } {
+  let removed: TreeItem | null = null;
+
+  const next = items
+    .map((item) => {
+      if (item.issue.id === issueId) {
+        removed = item;
+        return null;
+      }
+
+      const detached = detachNode(item.children, issueId);
+      if (detached.node) {
+        removed = detached.node;
+        return { ...item, children: detached.items };
+      }
+
+      return item;
+    })
+    .filter((item): item is TreeItem => item !== null);
+
+  return { items: next, node: removed };
+}
+
+function insertIntoParentByNumber(
+  items: TreeItem[],
+  parentIssueNumber: number,
+  node: TreeItem,
+  afterId?: IssueId,
+  beforeId?: IssueId
+): { items: TreeItem[]; inserted: boolean } {
+  let inserted = false;
+
+  const next = items.map((item) => {
+    if (item.issue.number === parentIssueNumber) {
+      inserted = true;
+      return {
+        ...item,
+        children: insertByAnchor(item.children, node, afterId, beforeId),
+      };
+    }
+
+    const nested = insertIntoParentByNumber(
+      item.children,
+      parentIssueNumber,
+      node,
+      afterId,
+      beforeId
+    );
+    if (nested.inserted) {
+      inserted = true;
+      return { ...item, children: nested.items };
+    }
+
+    return item;
+  });
+
+  return { items: next, inserted };
+}
+
+type PendingHierarchyOp =
+  | {
+      type: "move";
+      issueId: IssueId;
+      issueNumber: IssueNumber;
+      oldParentNumber: number | null;
+      newParentNumber: number | null;
+      afterId?: IssueId;
+      beforeId?: IssueId;
+    }
+  | {
+      type: "reorder";
+      parentIssueNumber: number;
+      childIssueId: IssueId;
+      afterId?: IssueId;
+      beforeId?: IssueId;
+    };
 
 /** Issue 操作用ミューテーションフック */
 export function useMutateIssue(owner: string, repo: string) {
   const { mutate } = useSWRConfig();  // グローバルミュータ
+  const pendingHierarchyOpsRef = useRef<Map<IssueId, PendingHierarchyOp>>(new Map());
+  const syncTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const isSyncingRef = useRef(false);
 
   /** 全 Issue キャッシュを再検証 */
   const revalidateAll = useCallback(() => {
     mutate((key: unknown) => typeof key === "string" && key.startsWith(`issues:${owner}/${repo}`), undefined, { revalidate: true });
     mutate((key: unknown) => typeof key === "string" && key.startsWith(`sub-issues:${owner}/${repo}`), undefined, { revalidate: true });
   }, [mutate, owner, repo]);
+
+  /** ローカルツリーを移動結果で更新（再取得なし） */
+  const applyLocalMove = useCallback(
+    (
+      issueId: IssueId,
+      newParentNumber: number | null,
+      afterId?: IssueId,
+      beforeId?: IssueId
+    ) => {
+      const { tree, setTree } = useTreeStore.getState();
+      const detached = detachNode(tree, issueId);
+      if (!detached.node) return;
+
+      if (newParentNumber === null) {
+        setTree(insertByAnchor(detached.items, detached.node, afterId, beforeId));
+        return;
+      }
+
+      const inserted = insertIntoParentByNumber(
+        detached.items,
+        newParentNumber,
+        detached.node,
+        afterId,
+        beforeId
+      );
+      setTree(inserted.inserted ? inserted.items : detached.items);
+    },
+    []
+  );
+
+  /** 階層変更のサーバー同期（キューは issue 単位で最新状態に圧縮） */
+  const flushHierarchyQueue = useCallback(async () => {
+    if (isSyncingRef.current) return;
+    if (pendingHierarchyOpsRef.current.size === 0) return;
+
+    isSyncingRef.current = true;
+    const batch = Array.from(pendingHierarchyOpsRef.current.values());
+    pendingHierarchyOpsRef.current.clear();
+
+    try {
+      for (const op of batch) {
+        if (op.type === "move") {
+          await moveIssueToParent(
+            owner,
+            repo,
+            op.issueNumber,
+            op.issueId,
+            op.oldParentNumber,
+            op.newParentNumber,
+            op.afterId,
+            op.beforeId
+          );
+        } else {
+          await reorderSubIssue(
+            owner,
+            repo,
+            op.parentIssueNumber,
+            op.childIssueId,
+            op.afterId,
+            op.beforeId
+          );
+        }
+      }
+    } catch (error) {
+      toast.error("同期に失敗しました。更新を押して再同期してください");
+      console.error(error);
+      revalidateAll();
+    } finally {
+      isSyncingRef.current = false;
+      if (pendingHierarchyOpsRef.current.size > 0) {
+        void flushHierarchyQueue();
+      }
+    }
+  }, [owner, repo, revalidateAll]);
+
+  /** 階層変更をキューに積み、短時間で圧縮して同期 */
+  const enqueueHierarchyOp = useCallback(
+    (op: PendingHierarchyOp) => {
+      const key = op.type === "move" ? op.issueId : op.childIssueId;
+      const prev = pendingHierarchyOpsRef.current.get(key);
+
+      if (!prev) {
+        pendingHierarchyOpsRef.current.set(key, op);
+      } else if (prev.type === "move" && op.type === "move") {
+        // 連続 move は「最初の oldParent」と「最後の行き先」を合成
+        pendingHierarchyOpsRef.current.set(key, {
+          ...op,
+          oldParentNumber: prev.oldParentNumber,
+        });
+      } else if (prev.type === "move" && op.type === "reorder") {
+        // move 後の reorder は move の最終配置として吸収
+        pendingHierarchyOpsRef.current.set(key, {
+          type: "move",
+          issueId: prev.issueId,
+          issueNumber: prev.issueNumber,
+          oldParentNumber: prev.oldParentNumber,
+          newParentNumber: op.parentIssueNumber,
+          afterId: op.afterId,
+          beforeId: op.beforeId,
+        });
+      } else {
+        // reorder -> move, reorder -> reorder は新しい操作を優先
+        pendingHierarchyOpsRef.current.set(key, op);
+      }
+
+      if (syncTimerRef.current) clearTimeout(syncTimerRef.current);
+      syncTimerRef.current = setTimeout(() => {
+        void flushHierarchyQueue();
+      }, 250);
+    },
+    [flushHierarchyQueue]
+  );
 
   /** Issue を作成 */
   const create = useCallback(
@@ -78,28 +302,30 @@ export function useMutateIssue(owner: string, repo: string) {
   const moveToParent = useCallback(
     async (
       issueId: IssueId,
+      issueNumber: IssueNumber,
       oldParentNumber: number | null,
       newParentNumber: number | null,
       afterId?: IssueId,
       beforeId?: IssueId
     ) => {
       try {
-        await moveIssueToParent(
-          owner,
-          repo,
+        // 体感速度優先: 先にローカル反映
+        applyLocalMove(issueId, newParentNumber, afterId, beforeId);
+        enqueueHierarchyOp({
+          type: "move",
           issueId,
+          issueNumber,
           oldParentNumber,
           newParentNumber,
           afterId,
-          beforeId
-        );
-        revalidateAll();
+          beforeId,
+        });
       } catch (error) {
         toast.error("階層の変更に失敗しました");
         console.error(error);
       }
     },
-    [owner, repo, revalidateAll]
+    [applyLocalMove, enqueueHierarchyOp]
   );
 
   /** 同一親内で並び替え */
@@ -111,21 +337,21 @@ export function useMutateIssue(owner: string, repo: string) {
       beforeId?: IssueId
     ) => {
       try {
-        await reorderSubIssue(
-          owner,
-          repo,
+        // 体感速度優先: 先にローカル反映
+        applyLocalMove(childIssueId, parentIssueNumber, afterId, beforeId);
+        enqueueHierarchyOp({
+          type: "reorder",
           parentIssueNumber,
           childIssueId,
           afterId,
-          beforeId
-        );
-        revalidateAll();
+          beforeId,
+        });
       } catch (error) {
         toast.error("並び替えに失敗しました");
         console.error(error);
       }
     },
-    [owner, repo, revalidateAll]
+    [applyLocalMove, enqueueHierarchyOp]
   );
 
   return { create, updateTitle, toggleState, moveToParent, reorder, revalidateAll };

--- a/src/hooks/useSubIssues.ts
+++ b/src/hooks/useSubIssues.ts
@@ -4,6 +4,8 @@ import useSWR from "swr";  // データフェッチ + キャッシュ
 import { getSubIssues } from "@/actions/hierarchy-actions";  // Server Action
 import type { GitHubIssue } from "@/lib/github/types";  // 型
 
+const EMPTY_SUB_ISSUES: GitHubIssue[] = [];
+
 /** 子 Issue 一覧を SWR で取得するフック */
 export function useSubIssues(
   owner: string,
@@ -22,7 +24,7 @@ export function useSubIssues(
   );
 
   return {
-    subIssues: data ?? [],
+    subIssues: data ?? EMPTY_SUB_ISSUES,
     error,
     isLoading,
     mutate,

--- a/src/lib/github/sub-issues.ts
+++ b/src/lib/github/sub-issues.ts
@@ -1,6 +1,32 @@
 import { Octokit } from "@octokit/rest";  // Octokit 型
 import type { GitHubIssue, IssueId } from "./types";  // 型インポート
 
+/** Sub-Issues API: 子 Issue の親 Issue 番号を取得 */
+export async function fetchParentIssueNumber(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  issueNumber: number
+): Promise<number | null> {
+  try {
+    const { data } = await octokit.request(
+      "GET /repos/{owner}/{repo}/issues/{issue_number}/parent",
+      {
+        owner,
+        repo,
+        issue_number: issueNumber,
+      }
+    );
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (data as any)?.number ?? null;
+  } catch (error) {
+    // 親がいない場合は 404
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    if ((error as any)?.status === 404) return null;
+    throw error;
+  }
+}
+
 /**
  * Sub-Issues API: 子 Issue 一覧を取得
  * GitHub Sub-Issues API は Issue の DB ID を使用する（number ではない）
@@ -92,7 +118,7 @@ export async function removeSubIssue(
   childIssueId: IssueId
 ): Promise<void> {
   await octokit.request(
-    "DELETE /repos/{owner}/{repo}/issues/{issue_number}/sub_issues",
+    "DELETE /repos/{owner}/{repo}/issues/{issue_number}/sub_issue",
     {
       owner,
       repo,

--- a/src/lib/keyboard/useKeyboardShortcuts.ts
+++ b/src/lib/keyboard/useKeyboardShortcuts.ts
@@ -16,6 +16,7 @@ interface Params {
   toggleState: (number: number, state: "open" | "closed") => Promise<void>;  // 状態切り替え
   moveToParent: (
     id: IssueId,
+    issueNumber: number,
     oldParent: number | null,
     newParent: number | null,
     afterId?: IssueId,
@@ -109,7 +110,12 @@ export function useKeyboardShortcuts({
           const oldParentNumber = getParentIssueNumber(flatItems, target.oldParentId);
           const newParent = flatItems.find((i) => i.issue.id === target.newParentId);
           if (newParent) {
-            moveToParent(focusedId, oldParentNumber, newParent.issue.number);
+            moveToParent(
+              focusedId,
+              focusedItem.issue.number,
+              oldParentNumber,
+              newParent.issue.number
+            );
           }
         }
         return;
@@ -124,7 +130,12 @@ export function useKeyboardShortcuts({
           const oldParent = flatItems.find((i) => i.issue.id === target.oldParentId);
           const newParentNumber = getParentIssueNumber(flatItems, target.newParentId);
           if (oldParent) {
-            moveToParent(focusedId, oldParent.issue.number, newParentNumber);
+            moveToParent(
+              focusedId,
+              focusedItem.issue.number,
+              oldParent.issue.number,
+              newParentNumber
+            );
           }
         }
         return;
@@ -166,6 +177,7 @@ export function useKeyboardShortcuts({
             const prevOfTarget = getSwapTarget(flatItems, target.issue.id, "up");
             moveToParent(
               focusedId,
+              focusedItem.issue.number,
               parentNumber,
               parentNumber,
               prevOfTarget?.issue.id,
@@ -184,6 +196,7 @@ export function useKeyboardShortcuts({
           if (parentNumber !== null) {
             moveToParent(
               focusedId,
+              focusedItem.issue.number,
               parentNumber,
               parentNumber,
               target.issue.id


### PR DESCRIPTION
Closes #3

## 変更内容
- Outliner に更新ボタンを追加し、Issue/Sub-issue を手動再取得できるようにした
- 階層操作を即時ローカル反映 + バックグラウンド同期キューに変更し、操作レスポンスを改善
- Sub-issue API のエンドポイント/親解決を修正し、移動時の整合性エラーを低減
- Breadcrumb の li ネストを解消して hydration エラーを修正
- 開発時の Auth secret と未認証時ガードを追加

## 検証
- npm test
- npm run lint（既存 warning のみ）